### PR TITLE
fix: Ensure edit permissions are checked before template file token g…

### DIFF
--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -185,7 +185,7 @@ class TokenManager {
 			$updatable = $updatable && $shareUpdatable;
 		}
 
-		$updatable = $updatable && $this->permissionManager->userCanEdit($editoruid);
+		$updatable = $updatable && $this->permissionManager->userCanEdit($owneruid);
 
 		$serverHost = $this->urlGenerator->getAbsoluteURL('/');
 

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -185,6 +185,8 @@ class TokenManager {
 			$updatable = $updatable && $shareUpdatable;
 		}
 
+		$updatable = $updatable && $this->permissionManager->userCanEdit($editoruid);
+
 		$serverHost = $this->urlGenerator->getAbsoluteURL('/');
 
 		return $this->wopiMapper->generateFileToken(


### PR DESCRIPTION
…eneration

otherwise file created from template will be editable for user with readonly permissions

wait for https://github.com/nextcloud/richdocuments/pull/4698 to be resolved


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
