### PR TITLE
IONOS: cherry-pick custom commits onto v9.0.5 (NC32)

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -387,6 +387,7 @@ export default {
 					this.$emit('update:loaded', true)
 					FilesAppIntegration.initAfterReady()
 				} else if (args.Status === 'Document_Loaded') {
+					this.sendPostMessage('Hide_Menu_Item', { id: 'help' })
 					this.documentReady()
 
 					if (loadState('richdocuments', 'open_local_editor', true) && !this.isEmbedded) {


### PR DESCRIPTION
## Summary

- Applies the IONOS custom commit(s) on top of the upstream v9.0.5 tag (NC32 baseline)
- `IONOS: feat: hide help menu` (Office.vue)
- `f1db58f` (`IONOS: fix: block doc creation for read-only share users`) — dropped: `NewFileMenu.js` / `OCA.Files.fileActions` were removed in NC32; backend protection is already present via `RegisterTemplateFileCreatorListener`
- `a0a63c3` (`IONOS: fix: allow document creation only for users that can edit`) — skipped: already incorporated in v9.0.5 upstream

## Purpose

Shows the exact diff introduced by IONOS on top of clean v9.0.5, and allows CI pipelines to run against it.