### PR TITLE
IONOS(richdocuments): NC33 fork release (HDNEXT-1593)

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -405,6 +405,7 @@ export default {
 					this.$emit('update:loaded', true)
 					FilesAppIntegration.initAfterReady()
 				} else if (args.Status === 'Document_Loaded') {
+					this.sendPostMessage('Hide_Menu_Item', { id: 'help' })
 					this.documentReady()
 
 					if (loadState('richdocuments', 'open_local_editor', true) && !this.isEmbedded) {


### PR DESCRIPTION
## Summary

Create the NC33 IONOS richdocuments line: upstream **v10.1.3** (NC 33–33, app 10.1.3) + the IONOS `hide help menu` patch.

- Integration branch `ionos-stable33` = vanilla upstream `v10.1.3`.
- This PR adds the one still-relevant IONOS commit on top: `IONOS: feat: hide help menu`.

## Reconciliation against upstream v10.1.3

HDNEXT-1593 originally listed **3** IONOS commits. Reconciling against v10.1.3, **2 became redundant** and were dropped (no loss of behavior):

| Ticket commit | Outcome |
|---|---|
| `24347e6` hide help menu | **kept** — applies cleanly, upstream still shows the menu |
| `f1db58f` client-side read-only gate (`src/public.js`) | **dropped** — upstream removed the entire `OCA.Files.NewFileMenu` registration block it modified; `NewFileMenu.js` no longer exists |
| `a0a63c3` server-side `userCanEdit` gate + test | **dropped** — upstream `RegisterTemplateFileCreatorListener` already gates on `userCanEdit()`; the IONOS behavior is now native |

So "block document creation for read-only users" is preserved by upstream's own server-side enforcement.

## Notes

- `js/` is gitignored; compiled assets are produced by the release build (as with the prior fork tag), so no asset commit here.
- Consumed by `IONOS-Productivity/nc-server#279` (NC33 ground slate) via a submodule-pointer bump after this merges + a prerelease tag is cut.

Jira: HDNEXT-1593